### PR TITLE
fix 브라우저 크기가 레이아웃보다 작은 경우 여백 없이 표시되는 부분 수정

### DIFF
--- a/src/components/Main/DummyMain/DummyMain.tsx
+++ b/src/components/Main/DummyMain/DummyMain.tsx
@@ -9,7 +9,7 @@ import DummyTopNav from '@components/Main/DummyMain/DummyTopNav';
 
 import * as S from './styled';
 
-const BefoerLogin: React.FC = () => {
+const BeforeLogin: React.FC = () => {
   return (
     <S.DummyWrapper>
       <S.DummyTopWrapper>
@@ -36,4 +36,4 @@ const BefoerLogin: React.FC = () => {
   );
 };
 
-export default BefoerLogin;
+export default BeforeLogin;

--- a/src/components/Main/DummyMain/styled.ts
+++ b/src/components/Main/DummyMain/styled.ts
@@ -6,8 +6,9 @@ import { RankListContainer } from '../MainContent/TotalTime.styled';
 export const DummyWrapper = styled.div(() => {
   return [
     css`
+      width: 100%;
       height: calc(100vh - 24px);
-      margin-top: 24px;
+      margin: 24px auto;
     `,
   ];
 });
@@ -18,6 +19,7 @@ export const DummyTopWrapper = styled.div(() => {
     css`
       background: ${theme.color.white};
       height: 35%;
+      padding: 0 20px;
     `,
   ];
 });
@@ -25,8 +27,7 @@ export const DummyTopWrapper = styled.div(() => {
 export const DummyContentWrapper = styled.div(() => {
   return [
     css`
-      max-width: 1320px;
-      min-width: 1320px;
+      width: 1340px;
       margin: 0 auto;
     `,
   ];
@@ -48,7 +49,10 @@ export const DummyBottonWrapper = styled.div(() => {
   return [
     css`
       background: ${theme.color.bgColor};
+      width: 100%;
+      min-width: 1380px;
       height: 65%;
+      padding: 0 20px;
     `,
   ];
 });


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 브라우저 크기가 레이아웃보다 작은 경우 여백 없이 표시되는 부분을 수정했어요.

- 이전
<img width="1295" alt="스크린샷 2022-10-11 22 12 13" src="https://user-images.githubusercontent.com/90027202/195100227-c77d48ab-b204-4cf6-a84a-b0894b6006a3.png">

- 이후
<img width="1295" alt="스크린샷 2022-10-11 22 12 37" src="https://user-images.githubusercontent.com/90027202/195100320-e629f2f5-3128-4d3f-9d3f-c31e42ae6684.png">

- 컴포넌트 이름이 befoer로 오타가 나 있는 부분을 수정했습니다.

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
